### PR TITLE
fix: listen for ucallstat 6 (disconnected) 

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -430,6 +430,7 @@ class GsmModem(SerialComms):
             self.log.info("Loading LARA-R211 call state update table")
             self._callStatusUpdates = (
                 (re.compile("^\+UCALLSTAT:\s*(\d+),(0|7)$"), self._handleCallAnswered),
+                (re.compile("^\+UCALLSTAT:\s*(\d+),(6)$"), self._handleCallEnded),
                 (re.compile("^NO\s*CARRIER$"), self._handleCallEnded),
                 (re.compile("^NO\s*CARRIER|ANSWER$"), self._handleCallRejected),
             )


### PR DESCRIPTION
UCALLSTAT URCs are faster than "NO ANSWER" or "NO CARRIER" when the call is rejected, not picked up or 5 is not pressed. This lets us react much faster